### PR TITLE
docs: 大小文字が英文として違和感があるので修正 #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 ## Discord Image Keeper
 
-Save images which is posted to Discord channels, Send zipped images with executing command.
+Save images which is posted to Discord channels, send zipped images with executing command.


### PR DESCRIPTION
## issue

https://github.com/mopeneko/discord-image-keeper/issues/1

## 修正箇所

", Send" を ", send" に